### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/dulli/caddy-wol/security/code-scanning/1](https://github.com/dulli/caddy-wol/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient because the workflow only checks out the code and builds/tests it without modifying repository contents or interacting with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions specifically for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
